### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8']
     name: test (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v2

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,26 +1,30 @@
 import nox
 
 
-@nox.session(reuse_venv=True)
+python_versions = ["3.7", "3.8"]
+default_python = "3.8"
+
+
+@nox.session(python=default_python, reuse_venv=True)
 def lint_black(session):
     session.install("black")
     session.run("black", "--check", "plangid", "noxfile.py")
 
 
-@nox.session(reuse_venv=True)
+@nox.session(python=default_python, reuse_venv=True)
 def lint_flake8(session):
     session.install("flake8")
     session.run("flake8", "plangid")
 
 
-@nox.session(python=["3.6", "3.7", "3.8"])
+@nox.session(python=python_versions)
 def test(session):
     session.install("poetry")
     session.run("poetry", "install")
     session.run("pytest", "--ignore=language-dataset")
 
 
-@nox.session(python="3.8")
+@nox.session(python=default_python)
 def dist(session):
     session.install("poetry")
     session.run("poetry", "install")

--- a/plangid/pipeline.py
+++ b/plangid/pipeline.py
@@ -1,7 +1,4 @@
-try:
-    import importlib.resources as importlib_resources
-except ImportError:
-    import importlib_resources
+import importlib.resources
 import gzip
 import os.path
 import os
@@ -95,7 +92,7 @@ class LanguagePipeline(Pipeline):
     @staticmethod
     def load(path=None):
         if path is None:
-            file = importlib_resources.open_binary("plangid", "model.pickle.gz")
+            file = importlib.resources.open_binary("plangid", "model.pickle.gz")
         else:
             file = path
         with gzip.open(file, "rb") as f:

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,15 +37,19 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "importlib-resources"
-version = "3.0.0"
-description = "Read resources from Python packages"
-category = "main"
+name = "importlib-metadata"
+version = "2.0.0"
+description = "Read metadata from Python packages"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
+[package.dependencies]
+zipp = ">=0.5"
+
 [package.extras]
-docs = ["sphinx", "rst.linker", "jaraco.packaging"]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -107,6 +111,9 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
 [package.extras]
 dev = ["pre-commit", "tox"]
 
@@ -138,6 +145,7 @@ python-versions = ">=3.5"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
@@ -227,10 +235,22 @@ category = "dev"
 optional = false
 python-versions = "*"
 
+[[package]]
+name = "zipp"
+version = "3.2.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.8"
-content-hash = "a24bc2ffd43449d15915806b6eb2d610ca7e19dcf55d2303addaf384730c4f4d"
+python-versions = ">=3.7"
+content-hash = "d8ec556df7f4c14d6e69d3c8c4dfc609873468b8170d8f90f85342a8773da168"
 
 [metadata.files]
 atomicwrites = [
@@ -249,9 +269,9 @@ colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
-importlib-resources = [
-    {file = "importlib_resources-3.0.0-py2.py3-none-any.whl", hash = "sha256:d028f66b66c0d5732dae86ba4276999855e162a749c92620a38c1d779ed138a7"},
-    {file = "importlib_resources-3.0.0.tar.gz", hash = "sha256:19f745a6eca188b490b1428c8d1d4a0d2368759f32370ea8fb89cad2ab1106c3"},
+importlib-metadata = [
+    {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
+    {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
 ]
 iniconfig = [
     {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
@@ -395,4 +415,8 @@ threadpoolctl = [
 toml = [
     {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+]
+zipp = [
+    {file = "zipp-3.2.0-py3-none-any.whl", hash = "sha256:43f4fa8d8bb313e65d8323a3952ef8756bf40f9a5c3ea7334be23ee4ec8278b6"},
+    {file = "zipp-3.2.0.tar.gz", hash = "sha256:b52f22895f4cfce194bc8172f3819ee8de7540aa6d873535a8668b730b8b411f"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,12 @@ include = [
 plangid = 'plangid.cli:cli'
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.7"
 click = ">=7.1.2"
 numpy = ">=1.19.2"
 pandas = ">=1.1.2"
 PyYAML = ">=5.3.1"
 scikit-learn = ">=0.23.2"
-importlib-resources = "^3.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=6.1.0"


### PR DESCRIPTION
Prepare for 3.7+ features (e.g. dataclasses).